### PR TITLE
Add a "max-age" parameter to the URL API

### DIFF
--- a/Core/Plugins/Basic/ClientCache.cs
+++ b/Core/Plugins/Basic/ClientCache.cs
@@ -10,7 +10,7 @@ namespace ImageResizer.Plugins.Basic {
     /// Provides default client-caching behavior. Sends Last-Modified header if present, and Expires header if &lt;clientcache minutes="value" /&gt; is configured.
     /// Also defaults Cache-control to Public for anonymous requests (and private for authenticated requests)
     /// </summary>
-    public class ClientCache:IPlugin{
+    public class ClientCache:IPlugin, IQuerystringPlugin {
 
         Config c;
         public IPlugin Install(Configuration.Config c) {
@@ -29,10 +29,18 @@ namespace ImageResizer.Plugins.Basic {
          */
 
         void Pipeline_PreHandleImage(System.Web.IHttpModule sender, System.Web.HttpContext context, Caching.IResponseArgs e) {
+            Instructions instructions = new Instructions(context.Request.QueryString);
+            int maxage = instructions.Get<int>("max-age", -1);
             int mins = c.get("clientcache.minutes", -1);
+            
             //Set the expires value if present
-            if (mins > 0)
+            //Use the querystring provided value as an override for the configuration default
+            if (maxage >= 0) {
+                // Convert a max-age value (timespan in seconds) to the equivalent expires value
+                e.ResponseHeaders.Expires = DateTime.UtcNow.AddSeconds(maxage);
+            } else if (mins > 0) {
                 e.ResponseHeaders.Expires = DateTime.UtcNow.AddMinutes(mins);
+            }
 
             //NDJ Jan-16-2013. The last modified date sent in the headers should NOT match the source modified date when using DiskCaching.
             //Setting this will prevent 304s from being sent properly.
@@ -44,7 +52,10 @@ namespace ImageResizer.Plugins.Basic {
                 e.ResponseHeaders.CacheControl = System.Web.HttpCacheability.Private;
             else
                 e.ResponseHeaders.CacheControl = System.Web.HttpCacheability.Public;
+        }
 
+        public IEnumerable<string> GetSupportedQuerystringKeys() {
+            return new string[] { "max-age" };
         }
 
         public bool Uninstall(Configuration.Config c) {


### PR DESCRIPTION
 Allows overriding of client caching headers on a per-image basis.
